### PR TITLE
PlayerUtils Null fix.

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/events/EventBus.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/EventBus.java
@@ -1,6 +1,7 @@
 package io.github.itzispyder.clickcrystals.events;
 
 import io.github.itzispyder.clickcrystals.Global;
+import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.lang.reflect.Method;
@@ -33,6 +34,10 @@ public class EventBus implements Global {
      * @param <E> event type
      */
     public <E extends Event> boolean pass(E event) {
+        if (PlayerUtils.playerNull()) {
+            // A unfortunate fix.
+            return false;
+        }
         listeners().forEach(listener -> {
             List<Method> methods = Arrays
                     .stream(listener.getClass().getDeclaredMethods())
@@ -50,6 +55,7 @@ public class EventBus implements Global {
     }
 
     public <C extends CallbackInfo, E extends Event> void passWithCallbackInfo(C info, E event, Consumer<CallbackInfo> action) {
+
         pass(event);
         if (event instanceof Cancellable c && c.isCancelled()) {
             action.accept(info);

--- a/src/main/java/io/github/itzispyder/clickcrystals/events/events/client/EntityDamageEvent.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/events/client/EntityDamageEvent.java
@@ -12,7 +12,13 @@ public class EntityDamageEvent extends Event {
     private final Entity entity;
 
     public EntityDamageEvent(EntityDamageS2CPacket packet) {
+        if (PlayerUtils.playerNull()) {
+            entity = null;
+            source = null;
+            return;
+        }
         var world = PlayerUtils.getWorld();
+
         this.source = packet.createDamageSource(world);
         this.entity = world.getEntityById(packet.entityId());
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
@@ -13,6 +13,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -54,7 +55,8 @@ public final class PlayerUtils implements Global {
                 return player().getWorld();
 
             } catch (Exception e) {
-                e.printStackTrace();
+
+                system.logger.error(ExceptionUtils.getStackTrace(e.fillInStackTrace()));
             }
         }
         return player().getWorld();
@@ -121,9 +123,7 @@ public final class PlayerUtils implements Global {
     }
 
     public static Entity getNearestEntity(World world, Entity exclude, Vec3d at, double range, Predicate<Entity> filter) {
-        List<Entity> candidates = world.getOtherEntities(exclude, Box.from(at).expand(range), filter).stream()
-                .sorted(Comparator.comparing(entity -> entity.getPos().distanceTo(at)))
-                .toList();
+        List<Entity> candidates = world.getOtherEntities(exclude, Box.from(at).expand(range), filter).stream().sorted(Comparator.comparing(entity -> entity.getPos().distanceTo(at))).toList();
 
         if (candidates.isEmpty()) {
             return null;

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
@@ -6,15 +6,12 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.network.PlayerListEntry;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.packet.Packet;
-import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.Difficulty;
 import net.minecraft.world.World;
 
 import java.util.Comparator;
@@ -111,7 +108,7 @@ public final class PlayerUtils implements Global {
         for (double x = box.minX; x <= box.maxX; x++) {
             for (double y = box.minY; y <= box.maxY; y++) {
                 for (double z = box.minZ; z <= box.maxZ; z++) {
-                    BlockPos pos = new BlockPos((int)Math.floor(x), (int)Math.floor(y), (int)Math.floor(z));
+                    BlockPos pos = new BlockPos((int) Math.floor(x), (int) Math.floor(y), (int) Math.floor(z));
                     BlockState state = world.getBlockState(pos);
 
                     if (state == null || state.isAir()) {
@@ -141,7 +138,7 @@ public final class PlayerUtils implements Global {
 
     public static PlayerEntity getNearestPlayer(double range, Predicate<Entity> filter) {
         if (playerNull()) return null;
-        return (PlayerEntity)getNearestEntity(getWorld(), player(), player().getPos(), range, entity -> entity instanceof PlayerEntity && filter.test(entity));
+        return (PlayerEntity) getNearestEntity(getWorld(), player(), player().getPos(), range, entity -> entity instanceof PlayerEntity && filter.test(entity));
     }
 
     public static boolean runOnNearestBlock(double range, BiPredicate<BlockPos, BlockState> filter, BiConsumer<BlockPos, BlockState> function) {

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/PlayerUtils.java
@@ -6,12 +6,15 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.network.PlayerListEntry;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.packet.Packet;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.Difficulty;
 import net.minecraft.world.World;
 
 import java.util.Comparator;
@@ -25,7 +28,7 @@ import java.util.function.Predicate;
 public final class PlayerUtils implements Global {
 
     public static boolean playerNull() {
-        return mc == null || mc.player == null;
+        return mc == null || mc.player == null || mc.world == null;
     }
 
     public static boolean playerNotNull() {
@@ -49,6 +52,14 @@ public final class PlayerUtils implements Global {
     }
 
     public static World getWorld() {
+        if (playerNull()) {
+            try {
+                return player().getWorld();
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
         return player().getWorld();
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

I've added a check in EventBus, to check if the player is null or the world is null, if the check fails the event won't go through. And for EntityDamageEvent. I figured out that it causes a kick and added a world null check to it, seemed to fix it.


# Checklist:

- [ ] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.