### PR TITLE
Fix extremely black entity shadow in FullBright

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLightmapTextureManager.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLightmapTextureManager.java
@@ -15,7 +15,7 @@ public abstract class MixinLightmapTextureManager {
     @Inject(method = "getBrightness", at = @At("RETURN"), cancellable = true)
     private static void getBrightness(DimensionType type, int lightLevel, CallbackInfoReturnable<Float> cir) {
         if (Module.isEnabled(FullBright.class)) {
-            cir.setReturnValue(15.0F);
+            cir.setReturnValue(1.0F);
         }
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

in MixinLightmapTextureManager. the return value was set to 15.0F when fullbright is enabled.
this causes a problem with the entity shadow being very black.
i fix this
![image](https://github.com/ItziSpyder/ClickCrystals/assets/98782759/899d64c3-dc53-4823-bdc7-266ce23fa5f8)
# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.



