### PR TITLE
Added an item check for the ElytraSwitch module (That was a really stupid mistake)

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinClientPlayerEntity.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinClientPlayerEntity.java
@@ -27,7 +27,9 @@ public class MixinClientPlayerEntity implements Global {
         var p = PlayerUtils.player();
         if (!p.isOnGround() && !p.isFallFlying() && !p.isTouchingWater() && !p.hasStatusEffect(StatusEffects.LEVITATION)) {
             HotbarUtils.search(ELYTRA);
-            InteractionUtils.inputUse();
+            if (HotbarUtils.isHolding(ELYTRA)) {
+                InteractionUtils.inputUse();
+            }
         }
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/ElytraSwitch.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/ElytraSwitch.java
@@ -34,7 +34,7 @@ public class ElytraSwitch extends DummyModule implements Listener, Global {
     private boolean fallFlying;
 
     public ElytraSwitch() {
-        super("Elytra Switch", Categories.CRYSTAL, "Swap to elytra from your hotbar whenever you are double jumping");
+        super("Elytra Switch", Categories.CRYSTAL, "Swap to elytra from your hotbar when ever you are double jumping");
     }
 
     @Override
@@ -68,19 +68,19 @@ public class ElytraSwitch extends DummyModule implements Listener, Global {
     public void onTouchDown() {
         if (chestplateSwitch.getVal()) {
             HotbarUtils.search(this::isChestplate);
-            InteractionUtils.inputUse();
+            if (HotbarUtils.isHoldingEitherHand(this::isChestplate)) {
+                InteractionUtils.inputUse();
+            }
         }
     }
 
     public void onDeparture() {
         if (rocketSwitch.getVal()) {
-            HotbarUtils.search(this::isRocket);
+            HotbarUtils.search(Items.FIREWORK_ROCKET);
+            HotbarUtils.isHolding(Items.FIREWORK_ROCKET);{
             InteractionUtils.inputUse();
+            }
         }
-    }
-
-    public boolean isRocket(ItemStack stack) {
-        return stack.getItem() == Items.FIREWORK_ROCKET;
     }
 
     public boolean isChestplate(ItemStack stack) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When I added #63 I forgot to add a check that check if `search` has been successful or not.
 that make it so:
```java
            InteractionUtils.inputUse();
```
will be executed whenever the `MixinClientPlayerEntity` is called

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.

